### PR TITLE
feat(error): add error handling helper

### DIFF
--- a/examples/types-from-definition.ts
+++ b/examples/types-from-definition.ts
@@ -1,5 +1,4 @@
 import {
-  makeCrudApi,
   ZodiosResponseByPath,
   ZodiosBodyByPath,
   ZodiosPathParamsByPath,

--- a/examples/types-from-definition.ts
+++ b/examples/types-from-definition.ts
@@ -6,6 +6,7 @@ import {
   ZodiosQueryParamsByPath,
   makeApi,
   ZodiosPathParamByAlias,
+  makeErrors,
 } from "../src/index";
 import z from "zod";
 
@@ -15,6 +16,28 @@ const user = z.object({
   email: z.string().email(),
   phone: z.string(),
 });
+
+const errors = makeErrors([
+  {
+    status: 404,
+    schema: z.object({
+      message: z.string(),
+    }),
+  },
+  {
+    status: 401,
+    schema: z.object({
+      message: z.string(),
+    }),
+  },
+  {
+    status: 500,
+    schema: z.object({
+      message: z.string(),
+      cause: z.record(z.string()),
+    }),
+  },
+]);
 
 const api = makeApi([
   {
@@ -34,6 +57,7 @@ const api = makeApi([
       },
     ],
     response: user,
+    errors,
   },
   {
     path: "/users",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { Zodios, ApiOf } from "./zodios";
-export { ZodiosError } from "./zodios-error";
+export { ZodiosError, ZodiosMatchingErrorType } from "./zodios-error";
 export type { ZodiosInstance, ZodiosClass, ZodiosConstructor } from "./zodios";
 export type {
   AnyZodiosMethodOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ export { Zodios } from "./zodios";
 export type { ApiOf } from "./zodios";
 export type { ZodiosInstance, ZodiosClass, ZodiosConstructor } from "./zodios";
 export { ZodiosError, ZodiosMatchingErrorType } from "./zodios-error";
-export { matchErrorByAlias, matchErrorByPath } from "./zodios-error.utils";
+export { isErrorFromPath, isErrorFromAlias } from "./zodios-error.utils";
 export type {
   AnyZodiosMethodOptions,
   AnyZodiosRequestOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
-export { Zodios, ApiOf } from "./zodios";
-export { ZodiosError, ZodiosMatchingErrorType } from "./zodios-error";
+export { Zodios } from "./zodios";
+export type { ApiOf } from "./zodios";
 export type { ZodiosInstance, ZodiosClass, ZodiosConstructor } from "./zodios";
+export { ZodiosError, ZodiosMatchingErrorType } from "./zodios-error";
+export { matchErrorByAlias, matchErrorByPath } from "./zodios-error.utils";
 export type {
   AnyZodiosMethodOptions,
   AnyZodiosRequestOptions,

--- a/src/plugins/zod-validation.plugin.ts
+++ b/src/plugins/zod-validation.plugin.ts
@@ -1,6 +1,6 @@
 import { ZodiosError } from "../zodios-error";
 import type { ZodiosOptions, ZodiosPlugin } from "../zodios.types";
-import { findEndpoint } from "./zodios-plugins.utils";
+import { findEndpoint } from "../utils";
 
 /**
  * Zod validation plugin used internally by Zodios.

--- a/src/plugins/zodios-plugins.utils.ts
+++ b/src/plugins/zodios-plugins.utils.ts
@@ -1,9 +1,0 @@
-import { ZodiosEndpointDefinitions } from "../zodios.types";
-
-export function findEndpoint(
-  api: ZodiosEndpointDefinitions,
-  method: string,
-  path: string
-) {
-  return api.find((e) => e.method === method && e.path === path);
-}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,10 @@
+import { AxiosError } from "axios";
 import { ReadonlyDeep } from "./utils.types";
-import { AnyZodiosRequestOptions } from "./zodios.types";
+import {
+  AnyZodiosRequestOptions,
+  ZodiosEndpointDefinition,
+  ZodiosEndpointDefinitions,
+} from "./zodios.types";
 
 /**
  * omit properties from an object
@@ -59,4 +64,48 @@ export function replacePathParams(
     );
   }
   return result;
+}
+
+export function findEndpoint(
+  api: ZodiosEndpointDefinitions,
+  method: string,
+  path: string
+) {
+  return api.find((e) => e.method === method && e.path === path);
+}
+
+export function findEndpointByAlias(
+  api: ZodiosEndpointDefinitions,
+  alias: string
+) {
+  return api.find((e) => e.alias === alias);
+}
+
+export function findEndpointError(
+  endpoint: ZodiosEndpointDefinition,
+  err: AxiosError
+) {
+  return (
+    endpoint.errors?.find((error) => error.status === err.response!.status) ??
+    endpoint.errors?.find((error) => error.status === "default")
+  );
+}
+
+export function findEndpointErrorByPath(
+  api: ZodiosEndpointDefinitions,
+  method: string,
+  path: string,
+  err: AxiosError
+) {
+  const endpoint = findEndpoint(api, method, path);
+  return endpoint ? findEndpointError(endpoint, err) : undefined;
+}
+
+export function findEndpointErrorByAlias(
+  api: ZodiosEndpointDefinitions,
+  alias: string,
+  err: AxiosError
+) {
+  const endpoint = findEndpointByAlias(api, alias);
+  return endpoint ? findEndpointError(endpoint, err) : undefined;
 }

--- a/src/zodios-error.ts
+++ b/src/zodios-error.ts
@@ -18,3 +18,11 @@ export class ZodiosError extends Error {
     super(message);
   }
 }
+
+export const ZodiosMatchingErrorType = {
+  ValidationError: "ZodiosValidationError",
+  UnexpectedError: "ZodiosUnexpectedError",
+  ExpectedError: "ZodiosExpectedError",
+  UnknownError: "UnknownError",
+  Error: "Error",
+} as const;

--- a/src/zodios-error.utils.ts
+++ b/src/zodios-error.utils.ts
@@ -1,0 +1,103 @@
+import { AxiosError } from "axios";
+import { findEndpointErrorByAlias, findEndpointErrorByPath } from "./utils";
+import { Merge } from "./utils.types";
+import { ZodiosError, ZodiosMatchingErrorType } from "./zodios-error";
+import {
+  Method,
+  ZodiosAliases,
+  ZodiosEndpointDefinitions,
+  ZodiosEndpointError,
+  ZodiosMatchingErrorsByAlias,
+  ZodiosMatchingErrorsByPath,
+  ZodiosPathsByMethod,
+} from "./zodios.types";
+
+function matchError(
+  error: unknown,
+  findEndpoint: (error: AxiosError) => ZodiosEndpointError | undefined
+) {
+  if (error instanceof ZodiosError) {
+    return { type: ZodiosMatchingErrorType.ValidationError, error };
+  }
+  if (
+    error instanceof AxiosError ||
+    (error && typeof error === "object" && "isAxiosError" in error)
+  ) {
+    const err = error as AxiosError;
+    if (err.response) {
+      const endpointError = findEndpoint(err);
+      if (endpointError) {
+        const result = endpointError.schema.safeParse(err.response!.data);
+        if (result.success) {
+          return {
+            type: ZodiosMatchingErrorType.ExpectedError,
+            error: err,
+            status: err.response.status,
+          } as any;
+        }
+      }
+    }
+    return { type: ZodiosMatchingErrorType.UnexpectedError, error: err };
+  }
+  if (error instanceof Error) {
+    return { type: ZodiosMatchingErrorType.Error, error };
+  }
+  return { type: ZodiosMatchingErrorType.UnknownError, error };
+}
+
+export function matchErrorByPath<
+  Api extends ZodiosEndpointDefinitions,
+  M extends Method,
+  Path extends ZodiosPathsByMethod<Api, M>
+>(
+  api: Api,
+  method: M,
+  path: Path,
+  error: unknown
+):
+  | {
+      type: typeof ZodiosMatchingErrorType.ValidationError;
+      error: ZodiosError;
+    }
+  | {
+      type: typeof ZodiosMatchingErrorType.UnexpectedError;
+      error: AxiosError;
+    }
+  | Merge<
+      { type: typeof ZodiosMatchingErrorType.ExpectedError },
+      ZodiosMatchingErrorsByPath<Api, M, Path>
+    >
+  | { type: typeof ZodiosMatchingErrorType.Error; error: Error }
+  | { type: typeof ZodiosMatchingErrorType.UnknownError; error: unknown } {
+  if (error instanceof ZodiosError) {
+    return { type: ZodiosMatchingErrorType.ValidationError, error };
+  }
+  return matchError(error, (e) =>
+    findEndpointErrorByPath(api, method, path, e)
+  );
+}
+
+export function matchErrorByAlias<
+  Api extends ZodiosEndpointDefinitions,
+  Alias extends keyof ZodiosAliases<Api>
+>(
+  api: Api,
+  alias: Alias,
+  error: unknown
+):
+  | {
+      type: typeof ZodiosMatchingErrorType.ValidationError;
+      error: ZodiosError;
+    }
+  | {
+      type: typeof ZodiosMatchingErrorType.UnexpectedError;
+      error: AxiosError;
+    }
+  | Merge<
+      { type: typeof ZodiosMatchingErrorType.ExpectedError },
+      ZodiosMatchingErrorsByAlias<Api, Alias>
+    >
+  | { type: typeof ZodiosMatchingErrorType.Error; error: Error }
+  | { type: typeof ZodiosMatchingErrorType.UnknownError; error: unknown } {
+  return matchError(error, (e) => findEndpointErrorByAlias(api, alias, e));
+}

--- a/src/zodios.test.ts
+++ b/src/zodios.test.ts
@@ -819,7 +819,6 @@ received:
             schema: z.object({
               error: z.object({
                 message: z.string(),
-                _502: z.literal(true),
               }),
             }),
           },
@@ -837,6 +836,7 @@ received:
             schema: z.object({
               error: z.object({
                 message: z.string(),
+                _default: z.literal(true),
               }),
             }),
           },
@@ -857,10 +857,7 @@ received:
       expect(match.status).toBe(502);
       if (match.status === 502) {
         const data = match.error.response!.data;
-        const test: Assert<
-          typeof data,
-          { error: { message: string; _502: true } }
-        > = true;
+        const test: Assert<typeof data, { error: { message: string } }> = true;
       }
       expect(match.error.response?.data).toEqual({
         error: { message: "bad gateway" },

--- a/src/zodios.test.ts
+++ b/src/zodios.test.ts
@@ -9,6 +9,7 @@ import multer from "multer";
 import { ZodiosPlugin } from "./zodios.types";
 import { apiBuilder } from "./api";
 import { matchErrorByAlias, matchErrorByPath } from "./zodios-error.utils";
+import { Assert } from "./utils.types";
 
 const multipart = multer({ storage: multer.memoryStorage() });
 
@@ -818,6 +819,24 @@ received:
             schema: z.object({
               error: z.object({
                 message: z.string(),
+                _502: z.literal(true),
+              }),
+            }),
+          },
+          {
+            status: 401,
+            schema: z.object({
+              error: z.object({
+                message: z.string(),
+                _401: z.literal(true),
+              }),
+            }),
+          },
+          {
+            status: "default",
+            schema: z.object({
+              error: z.object({
+                message: z.string(),
               }),
             }),
           },
@@ -836,6 +855,13 @@ received:
     expect(match.type).toBe("ZodiosExpectedError");
     if (match.type === "ZodiosExpectedError") {
       expect(match.status).toBe(502);
+      if (match.status === 502) {
+        const data = match.error.response!.data;
+        const test: Assert<
+          typeof data,
+          { error: { message: string; _502: true } }
+        > = true;
+      }
       expect(match.error.response?.data).toEqual({
         error: { message: "bad gateway" },
       });

--- a/src/zodios.test.ts
+++ b/src/zodios.test.ts
@@ -8,6 +8,7 @@ import { ZodiosError } from "./zodios-error";
 import multer from "multer";
 import { ZodiosPlugin } from "./zodios.types";
 import { apiBuilder } from "./api";
+import { matchErrorByAlias, matchErrorByPath } from "./zodios-error.utils";
 
 const multipart = multer({ storage: multer.memoryStorage() });
 
@@ -829,7 +830,7 @@ received:
     } catch (e) {
       error = e;
     }
-    const match = zodios.matchErrorByPath("get", "/error502", error);
+    const match = matchErrorByPath(zodios.api, "get", "/error502", error);
     expect(error).toBeInstanceOf(AxiosError);
     expect((error as AxiosError).response?.status).toBe(502);
     expect(match.type).toBe("ZodiosExpectedError");
@@ -839,7 +840,7 @@ received:
         error: { message: "bad gateway" },
       });
     }
-    const matchAlias = zodios.matchErrorByAlias("getError502", error);
+    const matchAlias = matchErrorByAlias(zodios.api, "getError502", error);
     expect(matchAlias.type).toBe("ZodiosExpectedError");
     if (matchAlias.type === "ZodiosExpectedError") {
       expect(matchAlias.status).toBe(502);
@@ -864,7 +865,7 @@ received:
     } catch (e) {
       error = e;
     }
-    const match = zodios.matchErrorByPath("get", "/error502", error);
+    const match = matchErrorByPath(zodios.api, "get", "/error502", error);
     expect(error).toBeInstanceOf(AxiosError);
     expect((error as AxiosError).response?.status).toBe(502);
     expect(match.type).toBe("ZodiosUnexpectedError");
@@ -873,7 +874,7 @@ received:
         error: { message: "bad gateway" },
       });
     }
-    const matchAlias = zodios.matchErrorByAlias("getError502", error);
+    const matchAlias = matchErrorByAlias(zodios.api, "getError502", error);
     expect(matchAlias.type).toBe("ZodiosUnexpectedError");
     if (matchAlias.type === "ZodiosUnexpectedError") {
       expect(matchAlias.error.response?.data).toEqual({

--- a/src/zodios.test.ts
+++ b/src/zodios.test.ts
@@ -864,7 +864,7 @@ received:
     if (isErrorFromAlias(zodios.api, "getError502", error)) {
       expect(error.response.status).toBe(502);
       if (error.response.status === 502) {
-        const data = error.response!.data;
+        const data = error.response.data;
         const test: Assert<typeof data, { error: { message: string } }> = true;
       }
       expect(error.response?.data).toEqual({

--- a/src/zodios.ts
+++ b/src/zodios.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError, AxiosInstance, AxiosRequestConfig } from "axios";
+import axios, { AxiosInstance, AxiosRequestConfig } from "axios";
 import {
   AnyZodiosRequestOptions,
   ZodiosRequestOptions,
@@ -11,16 +11,8 @@ import {
   ZodiosRequestOptionsByPath,
   ZodiosAliases,
   ZodiosPlugin,
-  ZodiosMatchingErrorsByPath,
-  ZodiosMatchingErrorsByAlias,
-  ZodiosEndpointError,
 } from "./zodios.types";
-import {
-  findEndpointErrorByAlias,
-  findEndpointErrorByPath,
-  omit,
-  replacePathParams,
-} from "./utils";
+import { omit, replacePathParams } from "./utils";
 import {
   PluginId,
   ZodiosPlugins,
@@ -30,14 +22,12 @@ import {
   headerPlugin,
 } from "./plugins";
 import {
-  Merge,
   Narrow,
   ReadonlyDeep,
   RequiredKeys,
   UndefinedIfNever,
 } from "./utils.types";
 import { checkApi } from "./api";
-import { ZodiosError, ZodiosMatchingErrorType } from "./zodios-error";
 
 /**
  * zodios api client based on axios
@@ -257,89 +247,6 @@ export class ZodiosClass<Api extends ZodiosEndpointDefinitions> {
         }
       }
     });
-  }
-
-  private matchError(
-    error: unknown,
-    findEndpoint: (error: AxiosError) => ZodiosEndpointError | undefined
-  ) {
-    if (error instanceof ZodiosError) {
-      return { type: ZodiosMatchingErrorType.ValidationError, error };
-    }
-    if (
-      error instanceof AxiosError ||
-      (error && typeof error === "object" && "isAxiosError" in error)
-    ) {
-      const err = error as AxiosError;
-      if (err.response) {
-        const endpointError = findEndpoint(err);
-        if (endpointError) {
-          const result = endpointError.schema.safeParse(err.response!.data);
-          if (result.success) {
-            return {
-              type: ZodiosMatchingErrorType.ExpectedError,
-              error: err,
-              status: err.response.status,
-            } as any;
-          }
-        }
-      }
-      return { type: ZodiosMatchingErrorType.UnexpectedError, error: err };
-    }
-    if (error instanceof Error) {
-      return { type: ZodiosMatchingErrorType.Error, error };
-    }
-    return { type: ZodiosMatchingErrorType.UnknownError, error };
-  }
-
-  matchErrorByPath<M extends Method, Path extends ZodiosPathsByMethod<Api, M>>(
-    method: M,
-    path: Path,
-    error: unknown
-  ):
-    | {
-        type: typeof ZodiosMatchingErrorType.ValidationError;
-        error: ZodiosError;
-      }
-    | {
-        type: typeof ZodiosMatchingErrorType.UnexpectedError;
-        error: AxiosError;
-      }
-    | Merge<
-        { type: typeof ZodiosMatchingErrorType.ExpectedError },
-        ZodiosMatchingErrorsByPath<Api, M, Path>
-      >
-    | { type: typeof ZodiosMatchingErrorType.Error; error: Error }
-    | { type: typeof ZodiosMatchingErrorType.UnknownError; error: unknown } {
-    if (error instanceof ZodiosError) {
-      return { type: ZodiosMatchingErrorType.ValidationError, error };
-    }
-    return this.matchError(error, (error) =>
-      findEndpointErrorByPath(this.api, method, path, error)
-    );
-  }
-
-  matchErrorByAlias<Alias extends keyof ZodiosAliases<Api>>(
-    alias: Alias,
-    error: unknown
-  ):
-    | {
-        type: typeof ZodiosMatchingErrorType.ValidationError;
-        error: ZodiosError;
-      }
-    | {
-        type: typeof ZodiosMatchingErrorType.UnexpectedError;
-        error: AxiosError;
-      }
-    | Merge<
-        { type: typeof ZodiosMatchingErrorType.ExpectedError },
-        ZodiosMatchingErrorsByAlias<Api, Alias>
-      >
-    | { type: typeof ZodiosMatchingErrorType.Error; error: Error }
-    | { type: typeof ZodiosMatchingErrorType.UnknownError; error: unknown } {
-    return this.matchError(error, (error) =>
-      findEndpointErrorByAlias(this.api, alias, error)
-    );
   }
 
   /**

--- a/src/zodios.ts
+++ b/src/zodios.ts
@@ -261,7 +261,7 @@ export class ZodiosClass<Api extends ZodiosEndpointDefinitions> {
 
   private matchError(
     error: unknown,
-    findEnpoint: (error: AxiosError) => ZodiosEndpointError | undefined
+    findEndpoint: (error: AxiosError) => ZodiosEndpointError | undefined
   ) {
     if (error instanceof ZodiosError) {
       return { type: ZodiosMatchingErrorType.ValidationError, error };
@@ -272,7 +272,7 @@ export class ZodiosClass<Api extends ZodiosEndpointDefinitions> {
     ) {
       const err = error as AxiosError;
       if (err.response) {
-        const endpointError = findEnpoint(err);
+        const endpointError = findEndpoint(err);
         if (endpointError) {
           const result = endpointError.schema.safeParse(err.response!.data);
           if (result.success) {

--- a/src/zodios.types.ts
+++ b/src/zodios.types.ts
@@ -120,7 +120,18 @@ export type ErrorsToAxios<T, Acc extends unknown[] = []> = T extends [
     ? Schema extends z.ZodTypeAny
       ? ErrorsToAxios<
           Tail,
-          [...Acc, { status: Status; error: AxiosError<z.output<Schema>> }]
+          [
+            ...Acc,
+            Merge<
+              Omit<AxiosError, "status" | "response">,
+              {
+                response: Merge<
+                  AxiosError<z.output<Schema>>["response"],
+                  { status: Status }
+                >;
+              }
+            >
+          ]
         >
       : Acc
     : Acc

--- a/src/zodios.types.ts
+++ b/src/zodios.types.ts
@@ -1,4 +1,9 @@
-import { AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios";
+import {
+  AxiosError,
+  AxiosInstance,
+  AxiosRequestConfig,
+  AxiosResponse,
+} from "axios";
 import type {
   FilterArrayByValue,
   MapSchemaParameters,
@@ -103,6 +108,38 @@ export type ZodiosErrorByPath<
     ZodiosDefaultErrorByPath<Api, M, Path>
   >
 >;
+
+export type ErrorsToAxios<T, Acc extends unknown[] = []> = T extends [
+  infer Head,
+  ...infer Tail
+]
+  ? Head extends {
+      status: infer Status;
+      schema: infer Schema;
+    }
+    ? Schema extends z.ZodTypeAny
+      ? ErrorsToAxios<
+          Tail,
+          [...Acc, { status: Status; error: AxiosError<z.output<Schema>> }]
+        >
+      : Acc
+    : Acc
+  : Acc;
+
+export type ZodiosMatchingErrorsByPath<
+  Api extends ZodiosEndpointDefinition[],
+  M extends Method,
+  Path extends ZodiosPathsByMethod<Api, M>
+> = ErrorsToAxios<
+  ZodiosEndpointDefinitionByPath<Api, M, Path>[number]["errors"]
+>[number];
+
+export type ZodiosMatchingErrorsByAlias<
+  Api extends ZodiosEndpointDefinition[],
+  Alias extends string
+> = ErrorsToAxios<
+  ZodiosEndpointDefinitionByAlias<Api, Alias>[number]["errors"]
+>[number];
 
 export type ZodiosErrorByAlias<
   Api extends ZodiosEndpointDefinition[],

--- a/website/docs/client/error.md
+++ b/website/docs/client/error.md
@@ -26,7 +26,7 @@ function isErrorFromAlias(api: ZodiosEndpointDefinitions, alias: string, error: 
 ## Example
 
 ```typescript
-import { isExpectedErrorByPath, makeApi, Zodios } from "@zodios/core";
+import { isErrorFromPath, makeApi, Zodios } from "@zodios/core";
 
 const api = makeApi([
   {

--- a/website/docs/client/error.md
+++ b/website/docs/client/error.md
@@ -1,0 +1,127 @@
+---
+sidebar_position: 2
+---
+
+# Client Error Handling
+
+Error handling is a very important part of any API client. Zodios provides helpers to handle errors in a typesafe way.
+Indeed, many things can go wrong when making a request to an API. The server can be down, the request can be malformed, the response can be malformed, the response can be a 404, etc.
+
+## `matchErrorByPath`
+
+`matchErrorByPath` is a helper function that allows you to match errors by their path. It is very useful when you have a lot of errors and you want to handle them in a typesafe way.
+
+```typescript
+function matchErrorByPath(api: ZodiosEndpointDefinitions, method: string, path: string, error: unknown): 
+{
+    type: typeof ZodiosMatchingErrorType.ValidationError;
+    error: ZodiosError;
+} | 
+{
+    type: typeof ZodiosMatchingErrorType.UnexpectedError;
+    error: AxiosError;
+} | 
+{
+    type: typeof ZodiosMatchingErrorType.ExpectedError;
+    error: AxiosError<InferredTypeByStatusAndPath>
+} |
+{
+    type: typeof ZodiosMatchingErrorType.Error;
+    error: Error;
+} | 
+{
+    type: typeof ZodiosMatchingErrorType.UnknownError;
+    error: unknown;
+};
+```
+
+## `matchErrorByAlias`
+
+`matchErrorByAlias` is a helper function that allows you to match errors by their alias. It is very useful when you have a lot of errors and you want to handle them in a typesafe way.
+
+```typescript
+function matchErrorByAlias(api: ZodiosEndpointDefinitions, alias: string, error: unknown): 
+{
+    type: typeof ZodiosMatchingErrorType.ValidationError;
+    error: ZodiosError;
+} | 
+{
+    type: typeof ZodiosMatchingErrorType.UnexpectedError;
+    error: AxiosError;
+} | 
+{
+    type: typeof ZodiosMatchingErrorType.ExpectedError;
+    error: AxiosError<InferredTypeByStatusAndPath>
+} |
+{
+    type: typeof ZodiosMatchingErrorType.Error;
+    error: Error;
+} | 
+{
+    type: typeof ZodiosMatchingErrorType.UnknownError;
+    error: unknown;
+};
+```
+
+## Example
+
+```typescript
+import { matchErrorByPath, makeApi, Zodios } from "@zodios/core";
+
+const api = makeApi([
+  {
+    path: "/users/:id",
+    method: "get",
+    alias: "getUser",
+    response: z.object({
+      id: z.number(),
+      name: z.string(),
+    }),
+    errors: [
+      {
+        status: 404,
+        schema: z.object({
+          message: z.string(),
+          specificTo404: z.string(),
+        }),
+      },
+      {
+        status: 'default',
+        schema: z.object({
+          message: z.string(),
+        }),
+      }
+    ],
+  },
+]);
+
+const apiClient = new Zodios(api);
+
+try {
+  const response = await apiClient.getUser({ id: 1 });
+} catch (error) {
+  // you can also do:
+  // - matchErrorByPath(zodios.api, "get", "/users/:id", error)
+  // - matchErrorByAlias(api, "getUser", error)
+  // - matchErrorByAlias(zodios.api, "getUser", error)
+  const match = matchErrorByPath(api, "get", "/users/:id", error);
+
+  if (match.type === "ValidationError") {
+    // match.error is a ZodiosError
+  } else if (match.type === "UnexpectedError") {
+    // match.error is an AxiosError but the response is cannot be determined at compile time
+    // the cause is usually an insufficient api errors definition
+  } else if (match.type === "ExpectedError") {
+    // match.error is an AxiosError and the response is determined at compile time
+    if(match.status === 404) {
+      // match.error.response.data is guaranteed to be of type { message: string, specificTo404: string }
+    } else {
+      // match.error.response.data is guaranteed to be of type { message: string }
+    }
+  } else if (match.type === "Error") {
+    // match.error is an Error
+  } else if (match.type === "UnknownError") {
+    // match.error is an unknown error
+  }
+}
+```

--- a/website/docs/client/error.md
+++ b/website/docs/client/error.md
@@ -7,66 +7,26 @@ sidebar_position: 2
 Error handling is a very important part of any API client. Zodios provides helpers to handle errors in a typesafe way.
 Indeed, many things can go wrong when making a request to an API. The server can be down, the request can be malformed, the response can be malformed, the response can be a 404, etc.
 
-## `matchErrorByPath`
+## `isErrorFromPath`
 
-`matchErrorByPath` is a helper function that allows you to match errors by their path. It is very useful when you have a lot of errors and you want to handle them in a typesafe way.
+`isErrorFromPath` is a type guard that allows you to check if an error is an expected error by its path. Allowing to have typesafe error handling.
 
-```typescript
-function matchErrorByPath(api: ZodiosEndpointDefinitions, method: string, path: string, error: unknown): 
-{
-    type: typeof ZodiosMatchingErrorType.ValidationError;
-    error: ZodiosError;
-} | 
-{
-    type: typeof ZodiosMatchingErrorType.UnexpectedError;
-    error: AxiosError;
-} | 
-{
-    type: typeof ZodiosMatchingErrorType.ExpectedError;
-    error: AxiosError<InferredTypeByStatusAndPath>
-} |
-{
-    type: typeof ZodiosMatchingErrorType.Error;
-    error: Error;
-} | 
-{
-    type: typeof ZodiosMatchingErrorType.UnknownError;
-    error: unknown;
-};
+```ts
+function isErrorFromPath(api: ZodiosEndpointDefinitions, method: string, path: string, error: unknown): error is AxiosError<ErrorsFromDefinition>
 ```
 
-## `matchErrorByAlias`
+## `isErrorFromAlias`
 
-`matchErrorByAlias` is a helper function that allows you to match errors by their alias. It is very useful when you have a lot of errors and you want to handle them in a typesafe way.
+`isErrorFromAlias` is a type guard that allows you to check if an error is an expected error by its alias. Allowing to have typesafe error handling.
 
-```typescript
-function matchErrorByAlias(api: ZodiosEndpointDefinitions, alias: string, error: unknown): 
-{
-    type: typeof ZodiosMatchingErrorType.ValidationError;
-    error: ZodiosError;
-} | 
-{
-    type: typeof ZodiosMatchingErrorType.UnexpectedError;
-    error: AxiosError;
-} | 
-{
-    type: typeof ZodiosMatchingErrorType.ExpectedError;
-    error: AxiosError<InferredTypeByStatusAndPath>
-} |
-{
-    type: typeof ZodiosMatchingErrorType.Error;
-    error: Error;
-} | 
-{
-    type: typeof ZodiosMatchingErrorType.UnknownError;
-    error: unknown;
-};
+```ts
+function isErrorFromAlias(api: ZodiosEndpointDefinitions, alias: string, error: unknown): error is AxiosError<ErrorsFromDefinition>
 ```
 
 ## Example
 
 ```typescript
-import { matchErrorByPath, makeApi, Zodios } from "@zodios/core";
+import { isExpectedErrorByPath, makeApi, Zodios } from "@zodios/core";
 
 const api = makeApi([
   {
@@ -101,27 +61,16 @@ try {
   const response = await apiClient.getUser({ id: 1 });
 } catch (error) {
   // you can also do:
-  // - matchErrorByPath(zodios.api, "get", "/users/:id", error)
-  // - matchErrorByAlias(api, "getUser", error)
-  // - matchErrorByAlias(zodios.api, "getUser", error)
-  const match = matchErrorByPath(api, "get", "/users/:id", error);
-
-  if (match.type === "ValidationError") {
-    // match.error is a ZodiosError
-  } else if (match.type === "UnexpectedError") {
-    // match.error is an AxiosError but the response is cannot be determined at compile time
-    // the cause is usually an insufficient api errors definition
-  } else if (match.type === "ExpectedError") {
-    // match.error is an AxiosError and the response is determined at compile time
-    if(match.status === 404) {
-      // match.error.response.data is guaranteed to be of type { message: string, specificTo404: string }
+  // - isErrorFromPath(zodios.api, "get", "/users/:id", error)
+  // - isErrorFromAlias(api, "getUser", error)
+  // - isErrorFromAlias(zodios.api, "getUser", error)
+  if(isErrorFromPath(api, "get", "/users/:id", error)){
+    // error type is now narrowed to an axios error with a response from the ones defined in the api
+    if(error.response.status === 404) {
+      // error.response.data is guaranteed to be of type { message: string, specificTo404: string }
     } else {
-      // match.error.response.data is guaranteed to be of type { message: string }
+      // error.response.data is guaranteed to be of type { message: string }
     }
-  } else if (match.type === "Error") {
-    // match.error is an Error
-  } else if (match.type === "UnknownError") {
-    // match.error is an unknown error
   }
 }
 ```

--- a/website/docs/client/plugins.md
+++ b/website/docs/client/plugins.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 # Client API plugins

--- a/website/docs/client/react.md
+++ b/website/docs/client/react.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 # React hooks

--- a/website/docs/client/solid.md
+++ b/website/docs/client/solid.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 # Solid hooks


### PR DESCRIPTION
Proposal for helper error handling:
- compile time type checking for expected errors
- runtime type matching for expected errors 

```ts
import { isErrorFromPath, makeApi, Zodios } from "@zodios/core";

const api = makeApi([
  {
    path: "/users/:id",
    method: "get",
    alias: "getUser",
    response: z.object({
      id: z.number(),
      name: z.string(),
    }),
    errors: [
      {
        status: 404,
        schema: z.object({
          message: z.string(),
          specificTo404: z.string(),
        }),
      },
      {
        status: 'default',
        schema: z.object({
          message: z.string(),
        }),
      }
    ],
  },
]);

const apiClient = new Zodios(api);

try {
  const response = await apiClient.getUser({ id: 1 });
} catch (error) {
  // you can also do:
  // - isErrorFromPath(zodios.api, "get", "/users/:id", error)
  // - isErrorFromAlias(api, "getUser", error)
  // - isErrorFromAlias(zodios.api, "getUser", error)
  if(isErrorFromPath(api, "get", "/users/:id", error)){
    // error type is now narrowed to an axios error with a response from the ones defined in the api
    if(error.response.status === 404) {
      // error.response.data is guaranteed to be of type { message: string, specificTo404: string }
    } else {
      // error.response.data is guaranteed to be of type { message: string }
    }
  }
}```