### PR TITLE
feat: ZodiosOptions.rawValues

### DIFF
--- a/src/plugins/zod-validation.plugin.test.ts
+++ b/src/plugins/zod-validation.plugin.test.ts
@@ -6,6 +6,11 @@ import { zodValidationPlugin } from "./zod-validation.plugin";
 
 describe("zodValidationPlugin", () => {
   const plugin = zodValidationPlugin({ validate: true, transform: true });
+  const pluginWithoutTransform = zodValidationPlugin({
+    validate: true,
+    transform: false,
+  });
+
   describe("request", () => {
     it("should be defined", () => {
       expect(plugin.request).toBeDefined();
@@ -47,6 +52,21 @@ describe("zodValidationPlugin", () => {
       });
     });
 
+    it("should not transform parameters", async () => {
+      const notTransformed = await pluginWithoutTransform.request!(
+        api,
+        createSampleConfig("/transform")
+      );
+
+      expect(notTransformed.data).toBe("123");
+      expect(notTransformed.queries).toStrictEqual({
+        sampleQueryParam: "456",
+      });
+      expect(notTransformed.headers).toStrictEqual({
+        sampleHeader: "789",
+      });
+    });
+
     it("should transform parameters (async)", async () => {
       const transformed = await plugin.request!(
         api,
@@ -59,6 +79,21 @@ describe("zodValidationPlugin", () => {
       });
       expect(transformed.headers).toStrictEqual({
         sampleHeader: "789_transformed",
+      });
+    });
+
+    it("should not transform parameters (async)", async () => {
+      const notTransformed = await pluginWithoutTransform.request!(
+        api,
+        createSampleConfig("/transformAsync")
+      );
+
+      expect(notTransformed.data).toBe("123");
+      expect(notTransformed.queries).toStrictEqual({
+        sampleQueryParam: "456",
+      });
+      expect(notTransformed.headers).toStrictEqual({
+        sampleHeader: "789",
       });
     });
 
@@ -111,6 +146,19 @@ describe("zodValidationPlugin", () => {
       });
     });
 
+    it("should not transform body", async () => {
+      const notTransformed = await pluginWithoutTransform.response!(
+        api,
+        createSampleConfig("/transform"),
+        createSampleResponse()
+      );
+
+      expect(notTransformed.data).toStrictEqual({
+        first: "123",
+        second: 111,
+      });
+    });
+
     it("should transform body (async)", async () => {
       const transformed = await plugin.response!(
         api,
@@ -121,6 +169,19 @@ describe("zodValidationPlugin", () => {
       expect(transformed.data).toStrictEqual({
         first: "123_transformed",
         second: 234,
+      });
+    });
+
+    it("should not transform body (async)", async () => {
+      const notTransformed = await pluginWithoutTransform.response!(
+        api,
+        createSampleConfig("/transformAsync"),
+        createSampleResponse()
+      );
+
+      expect(notTransformed.data).toStrictEqual({
+        first: "123",
+        second: 111,
       });
     });
 

--- a/src/plugins/zod-validation.plugin.test.ts
+++ b/src/plugins/zod-validation.plugin.test.ts
@@ -5,7 +5,7 @@ import { AnyZodiosRequestOptions } from "../zodios.types";
 import { zodValidationPlugin } from "./zod-validation.plugin";
 
 describe("zodValidationPlugin", () => {
-  const plugin = zodValidationPlugin(true);
+  const plugin = zodValidationPlugin({ validate: true, transform: true });
   describe("request", () => {
     it("should be defined", () => {
       expect(plugin.request).toBeDefined();

--- a/src/plugins/zod-validation.plugin.ts
+++ b/src/plugins/zod-validation.plugin.ts
@@ -2,14 +2,17 @@ import { ZodiosError } from "../zodios-error";
 import type { ZodiosOptions, ZodiosPlugin } from "../zodios.types";
 import { findEndpoint } from "../utils";
 
+type Options = Pick<ZodiosOptions, "validate" | "rawValues">;
+
 /**
  * Zod validation plugin used internally by Zodios.
  * By default zodios always validates the response.
  * @returns zod-validation plugin
  */
-export function zodValidationPlugin(
-  validate?: ZodiosOptions["validate"]
-): ZodiosPlugin {
+export function zodValidationPlugin({
+  validate,
+  rawValues,
+}: Options): ZodiosPlugin {
   return {
     name: "zod-validation",
     request:
@@ -64,7 +67,15 @@ export function zodValidationPlugin(
                     parsed.error
                   );
                 }
-                setParamsOf[type](name, parsed.data);
+                if (
+                  rawValues === true ||
+                  rawValues === "all" ||
+                  rawValues === "request"
+                ) {
+                  setParamsOf[type](name, value);
+                } else {
+                  setParamsOf[type](name, parsed.data);
+                }
               }
             }
             return conf;
@@ -100,7 +111,13 @@ export function zodValidationPlugin(
                   parsed.error
                 );
               }
-              response.data = parsed.data;
+              if (
+                rawValues !== true &&
+                rawValues !== "all" &&
+                rawValues !== "response"
+              ) {
+                response.data = parsed.data;
+              }
             }
             return response;
           }

--- a/src/plugins/zod-validation.plugin.ts
+++ b/src/plugins/zod-validation.plugin.ts
@@ -67,11 +67,7 @@ export function zodValidationPlugin({
                     parsed.error
                   );
                 }
-                if (
-                  transform === true ||
-                  transform === "all" ||
-                  transform === "request"
-                ) {
+                if (transform === true || transform === "request") {
                   setParamsOf[type](name, parsed.data);
                 } else {
                   setParamsOf[type](name, value);
@@ -111,11 +107,7 @@ export function zodValidationPlugin({
                   parsed.error
                 );
               }
-              if (
-                transform === true ||
-                transform === "all" ||
-                transform === "response"
-              ) {
+              if (transform === true || transform === "response") {
                 response.data = parsed.data;
               }
             }

--- a/src/plugins/zod-validation.plugin.ts
+++ b/src/plugins/zod-validation.plugin.ts
@@ -13,106 +13,122 @@ export function zodValidationPlugin({
   validate,
   transform,
 }: Options): ZodiosPlugin {
+  const validateRequest =
+    validate === true || validate === "all" || validate === "request";
+  const validateResponse =
+    validate === true || validate === "all" || validate === "response";
+  const transformRequest = transform === true || transform === "request";
+  const transformResponse = transform === true || transform === "response";
+
+  if (
+    (transformRequest && !validateRequest) ||
+    (transformResponse && !validateResponse)
+  ) {
+    console.warn(
+      "Zodios: validation is enabled.",
+      "ZodiosOptions.transform implies ZodiosOptions.validate",
+      "To suppress this warning, align the value of validate to transform when initializing Zodios"
+    );
+  }
+
   return {
     name: "zod-validation",
-    request:
-      validate === true || validate === "all" || validate === "request"
-        ? async (api, config) => {
-            const endpoint = findEndpoint(api, config.method, config.url);
-            if (!endpoint) {
-              throw new Error(
-                `No endpoint found for ${config.method} ${config.url}`
-              );
-            }
-            const { parameters } = endpoint;
-            if (!parameters) {
-              return config;
-            }
-            const conf = {
-              ...config,
-              queries: {
-                ...config.queries,
-              },
-              headers: {
-                ...config.headers,
-              },
-              params: {
-                ...config.params,
-              },
-            };
-            const paramsOf = {
-              Query: (name: string) => conf.queries?.[name],
-              Body: (_: string) => conf.data,
-              Header: (name: string) => conf.headers?.[name],
-              Path: (name: string) => conf.params?.[name],
-            };
-            const setParamsOf = {
-              Query: (name: string, value: any) =>
-                (conf.queries![name] = value),
-              Body: (_: string, value: any) => (conf.data = value),
-              Header: (name: string, value: any) =>
-                (conf.headers![name] = value),
-              Path: (name: string, value: any) => (conf.params![name] = value),
-            };
-            for (const parameter of parameters) {
-              const { name, schema, type } = parameter;
-              const value = paramsOf[type](name);
-              if (value) {
-                const parsed = await schema.safeParseAsync(value);
-                if (!parsed.success) {
-                  throw new ZodiosError(
-                    `Zodios: Invalid ${type} parameter '${name}'`,
-                    config,
-                    value,
-                    parsed.error
-                  );
-                }
-                if (transform === true || transform === "request") {
-                  setParamsOf[type](name, parsed.data);
-                } else {
-                  setParamsOf[type](name, value);
-                }
-              }
-            }
-            return conf;
+    request: validateRequest
+      ? async (api, config) => {
+          const endpoint = findEndpoint(api, config.method, config.url);
+          if (!endpoint) {
+            throw new Error(
+              `No endpoint found for ${config.method} ${config.url}`
+            );
           }
-        : undefined,
-    response:
-      validate === true || validate === "all" || validate === "response"
-        ? async (api, config, response) => {
-            const endpoint = findEndpoint(api, config.method, config.url);
-            /* istanbul ignore next */
-            if (!endpoint) {
-              throw new Error(
-                `No endpoint found for ${config.method} ${config.url}`
-              );
-            }
-            if (
-              response.headers?.["content-type"]?.includes("application/json")
-            ) {
-              const parsed = await endpoint.response.safeParseAsync(
-                response.data
-              );
+          const { parameters } = endpoint;
+          if (!parameters) {
+            return config;
+          }
+          const conf = {
+            ...config,
+            queries: {
+              ...config.queries,
+            },
+            headers: {
+              ...config.headers,
+            },
+            params: {
+              ...config.params,
+            },
+          };
+          const paramsOf = {
+            Query: (name: string) => conf.queries?.[name],
+            Body: (_: string) => conf.data,
+            Header: (name: string) => conf.headers?.[name],
+            Path: (name: string) => conf.params?.[name],
+          };
+          const setParamsOf = {
+            Query: (name: string, value: any) => (conf.queries![name] = value),
+            Body: (_: string, value: any) => (conf.data = value),
+            Header: (name: string, value: any) => (conf.headers![name] = value),
+            Path: (name: string, value: any) => (conf.params![name] = value),
+          };
+          for (const parameter of parameters) {
+            const { name, schema, type } = parameter;
+            const value = paramsOf[type](name);
+            if (value) {
+              const parsed = await schema.safeParseAsync(value);
               if (!parsed.success) {
                 throw new ZodiosError(
-                  `Zodios: Invalid response from endpoint '${endpoint.method} ${
-                    endpoint.path
-                  }'\nstatus: ${response.status} ${
-                    response.statusText
-                  }\ncause:\n${
-                    parsed.error.message
-                  }\nreceived:\n${JSON.stringify(response.data, null, 2)}`,
+                  `Zodios: Invalid ${type} parameter '${name}'`,
                   config,
-                  response.data,
+                  value,
                   parsed.error
                 );
               }
-              if (transform === true || transform === "response") {
-                response.data = parsed.data;
+              if (transformRequest) {
+                setParamsOf[type](name, parsed.data);
+              } else {
+                setParamsOf[type](name, value);
               }
             }
-            return response;
           }
-        : undefined,
+          return conf;
+        }
+      : undefined,
+    response: validateResponse
+      ? async (api, config, response) => {
+          const endpoint = findEndpoint(api, config.method, config.url);
+          /* istanbul ignore next */
+          if (!endpoint) {
+            throw new Error(
+              `No endpoint found for ${config.method} ${config.url}`
+            );
+          }
+          if (
+            response.headers?.["content-type"]?.includes("application/json")
+          ) {
+            const parsed = await endpoint.response.safeParseAsync(
+              response.data
+            );
+            if (!parsed.success) {
+              throw new ZodiosError(
+                `Zodios: Invalid response from endpoint '${endpoint.method} ${
+                  endpoint.path
+                }'\nstatus: ${response.status} ${
+                  response.statusText
+                }\ncause:\n${parsed.error.message}\nreceived:\n${JSON.stringify(
+                  response.data,
+                  null,
+                  2
+                )}`,
+                config,
+                response.data,
+                parsed.error
+              );
+            }
+            if (transformResponse) {
+              response.data = parsed.data;
+            }
+          }
+          return response;
+        }
+      : undefined,
   };
 }

--- a/src/plugins/zod-validation.plugin.ts
+++ b/src/plugins/zod-validation.plugin.ts
@@ -2,7 +2,7 @@ import { ZodiosError } from "../zodios-error";
 import type { ZodiosOptions, ZodiosPlugin } from "../zodios.types";
 import { findEndpoint } from "../utils";
 
-type Options = Pick<ZodiosOptions, "validate" | "rawValues">;
+type Options = Pick<ZodiosOptions, "validate" | "transform">;
 
 /**
  * Zod validation plugin used internally by Zodios.
@@ -11,7 +11,7 @@ type Options = Pick<ZodiosOptions, "validate" | "rawValues">;
  */
 export function zodValidationPlugin({
   validate,
-  rawValues,
+  transform,
 }: Options): ZodiosPlugin {
   return {
     name: "zod-validation",
@@ -68,13 +68,13 @@ export function zodValidationPlugin({
                   );
                 }
                 if (
-                  rawValues === true ||
-                  rawValues === "all" ||
-                  rawValues === "request"
+                  transform === true ||
+                  transform === "all" ||
+                  transform === "request"
                 ) {
-                  setParamsOf[type](name, value);
-                } else {
                   setParamsOf[type](name, parsed.data);
+                } else {
+                  setParamsOf[type](name, value);
                 }
               }
             }
@@ -112,9 +112,9 @@ export function zodValidationPlugin({
                 );
               }
               if (
-                rawValues !== true &&
-                rawValues !== "all" &&
-                rawValues !== "response"
+                transform === true ||
+                transform === "all" ||
+                transform === "response"
               ) {
                 response.data = parsed.data;
               }

--- a/src/zodios.ts
+++ b/src/zodios.ts
@@ -13,7 +13,7 @@ import {
   ZodiosPlugin,
   Aliases,
 } from "./zodios.types";
-import { omit, replacePathParams } from "./utils";
+import { omit, pick, replacePathParams } from "./utils";
 import {
   PluginId,
   ZodiosPlugins,
@@ -96,6 +96,7 @@ export class ZodiosClass<Api extends ZodiosEndpointDefinitions> {
 
     this.options = {
       validate: true,
+      rawValues: true,
       ...options,
     };
 
@@ -114,7 +115,9 @@ export class ZodiosClass<Api extends ZodiosEndpointDefinitions> {
       this.options.validate &&
       [true, "all", "request", "response"].includes(this.options.validate)
     ) {
-      this.use(zodValidationPlugin(this.options.validate));
+      this.use(
+        zodValidationPlugin(pick(this.options, ["validate", "rawValues"]))
+      );
     }
   }
 

--- a/src/zodios.ts
+++ b/src/zodios.ts
@@ -96,7 +96,7 @@ export class ZodiosClass<Api extends ZodiosEndpointDefinitions> {
 
     this.options = {
       validate: true,
-      rawValues: true,
+      transform: true,
       ...options,
     };
 
@@ -116,7 +116,7 @@ export class ZodiosClass<Api extends ZodiosEndpointDefinitions> {
       [true, "all", "request", "response"].includes(this.options.validate)
     ) {
       this.use(
-        zodValidationPlugin(pick(this.options, ["validate", "rawValues"]))
+        zodValidationPlugin(pick(this.options, ["validate", "transform"]))
       );
     }
   }

--- a/src/zodios.types.ts
+++ b/src/zodios.types.ts
@@ -568,6 +568,10 @@ export type ZodiosOptions = {
    */
   validate?: boolean | "request" | "response" | "all" | "none";
   /**
+   * Use raw values from request/response rather than parsed values. Default: true
+   */
+  rawValues?: boolean | "request" | "response" | "all" | "none";
+  /**
    * Override the default axios instance. Default: zodios will create it's own axios instance
    */
   axiosInstance?: AxiosInstance;

--- a/src/zodios.types.ts
+++ b/src/zodios.types.ts
@@ -568,9 +568,9 @@ export type ZodiosOptions = {
    */
   validate?: boolean | "request" | "response" | "all" | "none";
   /**
-   * Use raw values from request/response rather than parsed values. Default: true
+   * Should zodios transform the request and response ? Default: true
    */
-  rawValues?: boolean | "request" | "response" | "all" | "none";
+  transform?: boolean | "request" | "response" | "all" | "none";
   /**
    * Override the default axios instance. Default: zodios will create it's own axios instance
    */

--- a/src/zodios.types.ts
+++ b/src/zodios.types.ts
@@ -570,7 +570,7 @@ export type ZodiosOptions = {
   /**
    * Should zodios transform the request and response ? Default: true
    */
-  transform?: boolean | "request" | "response" | "all" | "none";
+  transform?: boolean | "request" | "response";
   /**
    * Override the default axios instance. Default: zodios will create it's own axios instance
    */

--- a/website/docs/client/client.md
+++ b/website/docs/client/client.md
@@ -103,11 +103,16 @@ Indeed, they are automatically deduced from the path and added to the request pa
 
 Zodios API client constructor options `ZodiosOptions` are straightforward.
 
-| Option        | Type                                          | Default        | Description                                   |
-| ------------- | --------------------------------------------- | -------------- | --------------------------------------------- |
-| validate      | boolean \| all \| none \| request \| response | true           | Validate parameters and responses at runtime. |
-| axiosInstance | AxiosInstance                                 | axios.create() | add your own axios instance                   |
-| axiosConfig   | AxiosRequestConfig                            | {}             | add your own default axios config             |
+| Option        | Type                                          | Default        | Description                                    |
+| ------------- | --------------------------------------------- | -------------- | ---------------------------------------------- |
+| validate      | boolean \| all \| none \| request \| response | true           | Validate parameters and responses at runtime.  |
+| transform     | boolean \| request \| response                | true           | Transform parameters and responses at runtime. |
+| axiosInstance | AxiosInstance                                 | axios.create() | add your own axios instance                    |
+| axiosConfig   | AxiosRequestConfig                            | {}             | add your own default axios config              |
+
+:::note transform implies validation
+In order to transform data, zod needs to parse the data successfully.
+:::
 
 ## Zodios attributes
 


### PR DESCRIPTION
I think it is good to separate validation and parsing logic.
I make a purposal to allow using raw request/response data like what [react-hook-form](https://github.com/react-hook-form/resolvers#api) did.

If this idea is reasonable, I'll try to finish up testing and docs.