### PR TITLE
fix: not able to run jsonplaceholder example

### DIFF
--- a/examples/jsonplaceholder.ts
+++ b/examples/jsonplaceholder.ts
@@ -42,7 +42,7 @@ async function bootstrap() {
       path: "/users/:id",
       alias: "deleteUser",
       description: "Delete a user",
-      response: z.void(),
+      response: z.object({ }),
     },
     {
       method: "post",


### PR DESCRIPTION
hi ! 

It's my first time using zodios and I wanted to run some examples to test the library but when deleting a user in the example, zod was not happy receiving an object instead of void like it was defined in the schema.
