### PR TITLE
Fix types for "NodeNext" module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "import": "./lib/index.mjs",
-      "require": "./lib/index.js"
+      "require": "./lib/index.js",
+      "types": "./lib/index.d.ts"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
When a typescript project uses the `NodeNext` option for the `moduleResolution` in the tsconfig, the types are missing. They also have to be set for the exports, otherwise the compiler can't find the types. This probably need to be also changed for the other packages.

I've checked that it worked by creating a new project with this option and linked the package to the local version. After this, the type information reappeared and the compiler was happy again.