### PR TITLE
add lib exports to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,11 @@
       "require": "./lib/index.js",
       "types": "./lib/index.d.ts"
     },
+    "./lib/*": {
+      "import": "./lib/*.mjs",
+      "require": "./lib/*.js",
+      "types": "./lib/*"
+    },
     "./package.json": "./package.json"
   },
   "files": [


### PR DESCRIPTION
`package.json` `exports` only exports `index.js/d.ts/mjs` but `@zodios/express` depends on `utils.types.ts` so it is broken when using node16's module resolution with ts. This PR exports the entire `lib` folder. Files from `lib` do need to be prefixed with `/lib/` when imported for backward compatibility (e.g. `import { IfEquals, Narrow } from '@zodios/core/lib/utils.types';`), albeit it is possible to get rid of it.

Fixes https://github.com/ecyrbe/zodios-express/issues/108.