### PR TITLE
isErrorFromAlias retruns false incorrectly

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -96,13 +96,18 @@ export function findEndpointErrorsByPath(
   api: ZodiosEndpointDefinitions,
   method: string,
   path: string,
-  err: AxiosError
+  err: AxiosError,
+  params: Record<string, unknown>
 ) {
   const endpoint = findEndpoint(api, method, path);
   return endpoint &&
     err.config &&
     endpoint.method === err.config.method &&
-    endpoint.path === err.config.url
+    replacePathParams({
+      method: endpoint.method,
+      url: endpoint.path,
+      params,
+    }) === err.config.url
     ? findEndpointErrors(endpoint, err)
     : undefined;
 }
@@ -110,13 +115,18 @@ export function findEndpointErrorsByPath(
 export function findEndpointErrorsByAlias(
   api: ZodiosEndpointDefinitions,
   alias: string,
-  err: AxiosError
+  err: AxiosError,
+  params: Record<string, unknown>
 ) {
   const endpoint = findEndpointByAlias(api, alias);
   return endpoint &&
     err.config &&
     endpoint.method === err.config.method &&
-    endpoint.path === err.config.url
+    replacePathParams({
+      method: endpoint.method,
+      url: endpoint.path,
+      params,
+    }) === err.config.url
     ? findEndpointErrors(endpoint, err)
     : undefined;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -96,18 +96,14 @@ export function findEndpointErrorsByPath(
   api: ZodiosEndpointDefinitions,
   method: string,
   path: string,
-  err: AxiosError,
-  params: Record<string, unknown>
+  err: AxiosError
 ) {
   const endpoint = findEndpoint(api, method, path);
   return endpoint &&
     err.config &&
+    err.config.url &&
     endpoint.method === err.config.method &&
-    replacePathParams({
-      method: endpoint.method,
-      url: endpoint.path,
-      params,
-    }) === err.config.url
+    pathMatchesUrl(endpoint.path, err.config.url)
     ? findEndpointErrors(endpoint, err)
     : undefined;
 }
@@ -115,18 +111,21 @@ export function findEndpointErrorsByPath(
 export function findEndpointErrorsByAlias(
   api: ZodiosEndpointDefinitions,
   alias: string,
-  err: AxiosError,
-  params: Record<string, unknown>
+  err: AxiosError
 ) {
   const endpoint = findEndpointByAlias(api, alias);
+
   return endpoint &&
     err.config &&
+    err.config.url &&
     endpoint.method === err.config.method &&
-    replacePathParams({
-      method: endpoint.method,
-      url: endpoint.path,
-      params,
-    }) === err.config.url
+    pathMatchesUrl(endpoint.path, err.config.url)
     ? findEndpointErrors(endpoint, err)
     : undefined;
+}
+
+export function pathMatchesUrl(path: string, url: string) {
+  return new RegExp(`^${path.replace(paramsRegExp, () => "([^/]+)")}$`).test(
+    url
+  );
 }

--- a/src/zodios-error.utils.ts
+++ b/src/zodios-error.utils.ts
@@ -47,10 +47,11 @@ export function isErrorFromPath<
   api: Api,
   method: M,
   path: Path,
-  error: unknown
+  error: unknown,
+  params: Record<string, unknown> = {}
 ): error is ZodiosMatchingErrorsByPath<Api, M, Path> {
   return isDefinedError(error, (err) =>
-    findEndpointErrorsByPath(api, method, path, err)
+    findEndpointErrorsByPath(api, method, path, err, params)
   );
 }
 
@@ -67,9 +68,10 @@ export function isErrorFromAlias<
 >(
   api: Api,
   alias: Alias,
-  error: unknown
+  error: unknown,
+  params: Record<string, unknown> = {}
 ): error is ZodiosMatchingErrorsByAlias<Api, Alias> {
   return isDefinedError(error, (err) =>
-    findEndpointErrorsByAlias(api, alias, err)
+    findEndpointErrorsByAlias(api, alias, err, params)
   );
 }

--- a/src/zodios-error.utils.ts
+++ b/src/zodios-error.utils.ts
@@ -47,11 +47,10 @@ export function isErrorFromPath<
   api: Api,
   method: M,
   path: Path,
-  error: unknown,
-  params: Record<string, unknown> = {}
+  error: unknown
 ): error is ZodiosMatchingErrorsByPath<Api, M, Path> {
   return isDefinedError(error, (err) =>
-    findEndpointErrorsByPath(api, method, path, err, params)
+    findEndpointErrorsByPath(api, method, path, err)
   );
 }
 
@@ -68,10 +67,9 @@ export function isErrorFromAlias<
 >(
   api: Api,
   alias: Alias,
-  error: unknown,
-  params: Record<string, unknown> = {}
+  error: unknown
 ): error is ZodiosMatchingErrorsByAlias<Api, Alias> {
   return isDefinedError(error, (err) =>
-    findEndpointErrorsByAlias(api, alias, err, params)
+    findEndpointErrorsByAlias(api, alias, err)
   );
 }

--- a/src/zodios.test.ts
+++ b/src/zodios.test.ts
@@ -30,6 +30,9 @@ describe("Zodios", () => {
     app.get("/error401", (req, res) => {
       res.status(401).json({});
     });
+    app.get("/error/:id/error401", (req, res) => {
+      res.status(401).json({});
+    });
     app.get("/error502", (req, res) => {
       res.status(502).json({ error: { message: "bad gateway" } });
     });
@@ -893,6 +896,40 @@ received:
         error: { message: "bad gateway" },
       });
     }
+  });
+
+  it("should match error with params", async () => {
+    const zodios = new Zodios(`http://localhost:${port}`, [
+      {
+        method: "get",
+        alias: "getError401",
+        path: "/error/:id/error401",
+        response: z.void(),
+        errors: [
+          {
+            status: 401,
+            schema: z.object({}),
+          },
+        ],
+      },
+    ]);
+
+    const params = {
+      id: "test",
+    };
+
+    let error;
+    try {
+      await zodios.getError401({ params });
+    } catch (e) {
+      error = e;
+    }
+    expect(isErrorFromAlias(zodios.api, "getError401", error, params)).toBe(
+      true
+    );
+    expect(
+      isErrorFromPath(zodios.api, "get", "/error/:id/error401", error, params)
+    ).toBe(true);
   });
 
   it("should match Unexpected error", async () => {

--- a/src/zodios.test.ts
+++ b/src/zodios.test.ts
@@ -912,6 +912,18 @@ received:
           },
         ],
       },
+      {
+        method: "get",
+        alias: "getError404",
+        path: "/error/:id/error404",
+        response: z.void(),
+        errors: [
+          {
+            status: 404,
+            schema: z.object({}),
+          },
+        ],
+      },
     ]);
 
     const params = {
@@ -924,12 +936,16 @@ received:
     } catch (e) {
       error = e;
     }
-    expect(isErrorFromAlias(zodios.api, "getError401", error, params)).toBe(
-      true
-    );
+
+    expect(isErrorFromAlias(zodios.api, "getError401", error)).toBe(true);
+    expect(isErrorFromAlias(zodios.api, "getError404", error)).toBe(false);
+
     expect(
-      isErrorFromPath(zodios.api, "get", "/error/:id/error401", error, params)
+      isErrorFromPath(zodios.api, "get", "/error/:id/error401", error)
     ).toBe(true);
+    expect(
+      isErrorFromPath(zodios.api, "get", "/error/:id/error404", error)
+    ).toBe(false);
   });
 
   it("should match Unexpected error", async () => {


### PR DESCRIPTION
Hey,

It seems like isErrorFromAlias and isErrorFromPath don't work when a parameter is used.

I think the issue is in [this line](https://github.com/ecyrbe/zodios/blob/ac62b3b1de12ebba3dbb50c1bc06175945f7674b/src/utils.ts#L119) since `endpoint.path` contains the placeholder e.g :id while `err.config.url` contains the actual value.  