### PR TITLE
fix: replace axios mention with tanstack query

### DIFF
--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -31,10 +31,10 @@ function HomepageHeader() {
             <li>
               Standalone typesafe API client based on{" "}
               <a
-                href="https://axios-http.com/"
+                href="https://tanstack.com/query"
                 style={{ color: "white", textDecoration: "underline" }}
               >
-                Axios
+                TanStack Query
               </a>{" "}
               with parameters and response validation
             </li>


### PR DESCRIPTION
According to the [documentation](https://www.zodios.org/docs/intro), the client API is based on TanStack Query.

Closes #334