### PR TITLE
Update plugins docs for errors handling

### DIFF
--- a/website/docs/client/plugins.md
+++ b/website/docs/client/plugins.md
@@ -134,7 +134,7 @@ export type ZodiosPlugin = {
    * @param api - the api description
    * @param config - the config for the request
    * @param error - the error that occured
-   * @returns possibly a new response or a new error
+   * @returns possibly a new response or throw a new error
    */
   error?: (
     api: ZodiosEnpointDescriptions,


### PR DESCRIPTION
Because I don't want anybody to get insane to looking everywhere why my new errors was not working it's look like you need to throw the error instead of returning it.