### PR TITLE
Enable validation/transformation of JSON:API responses

### DIFF
--- a/src/plugins/zod-validation.plugin.test.ts
+++ b/src/plugins/zod-validation.plugin.test.ts
@@ -186,6 +186,23 @@ describe("zodValidationPlugin", () => {
       });
     });
 
+    it("should transform JSON:API body", async () => {
+      const transformed = await plugin.response!(
+        api,
+        createSampleConfig("/transform"),
+        createSampleResponse({
+          headers: {
+            "content-type": "application/vnd.api+json; charset=utf-8",
+          },
+        })
+      );
+
+      expect(transformed.data).toStrictEqual({
+        first: "123_transformed",
+        second: 234,
+      });
+    });
+
     it("should not transform body when transform is disabled", async () => {
       const notTransformed = await pluginWithoutTransform.response!(
         api,
@@ -290,16 +307,16 @@ received:
     url,
   });
 
-  const createSampleResponse = () =>
+  const createSampleResponse = (
+    { headers } = { headers: { "content-type": "application/json" } }
+  ) =>
     ({
       data: {
         first: "123",
         second: 111,
       },
       status: 200,
-      headers: {
-        "content-type": "application/json",
-      },
+      headers: headers,
       config: {},
       statusText: "OK",
     } as unknown as AxiosResponse);

--- a/src/plugins/zod-validation.plugin.ts
+++ b/src/plugins/zod-validation.plugin.ts
@@ -94,7 +94,10 @@ export function zodValidationPlugin({
             );
           }
           if (
-            response.headers?.["content-type"]?.includes("application/json")
+            response.headers?.["content-type"]?.includes("application/json") ||
+            response.headers?.["content-type"]?.includes(
+              "application/vnd.api+json"
+            )
           ) {
             const parsed = await endpoint.response.safeParseAsync(
               response.data


### PR DESCRIPTION
APIs that follow the [JSON:API](https://jsonapi.org/) specification use `application/vnd.api+json` instead of `application/json` as the value of the `Content-Type` header on responses.

zodios returns these responses without validation or transformation; this PR updates that behaviour to transform them as well. 

It's safe to validate/transform these responses as they are still plain JSON, see [7 Document Structure](https://jsonapi.org/format/#document-structure).

