### PR TITLE
Allow Module Augmentation of ZodiosEndpointDefinition

### DIFF
--- a/src/zodios.types.ts
+++ b/src/zodios.types.ts
@@ -626,7 +626,7 @@ export type ZodiosEndpointErrors = ZodiosEndpointError[];
 /**
  * Zodios enpoint definition that should be used to create a new instance of Zodios
  */
-export type ZodiosEndpointDefinition<R = unknown> = {
+export interface ZodiosEndpointDefinition<R = unknown> {
   /**
    * http method : get, post, put, patch, delete
    */


### PR DESCRIPTION
I want to enforce aliases on all endpoints but can't without playing fun typescript games. By converting the `ZodiosEndpointDefinition` type to an interface, this can now easily be done with [module augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation).

In addition to being able to modify which fields are required, additional fields could be added. This can be useful if a developer wanted to reuse the endpoint definitions for other purposes and needed additional meta data that wasn't provided by zodios out of the box.
