### PR TITLE
Added override example for formDataPlugin

### DIFF
--- a/website/docs/client/plugins.md
+++ b/website/docs/client/plugins.md
@@ -71,6 +71,22 @@ For example, you can override internal 'zod-validation' plugin with your own val
   });
 ```
 
+Some Zodios plugins are registered per-endpoint. For example, you cannot override `formDataPlugin` globally. Instead, you should do:
+
+```typescript
+  import { formDataPlugin } from '@zodios/core';
+  import { myFormDataPlugin } from './my-custom-formdata';
+ 
+  for(const endpoint of apiClient.api) {
+    if(endpoint.requestFormat === 'form-data') {
+      apiClient.use(endpoint.alias, {
+        name: formDataPlugin().name, // using the same name as an already existing plugin will override it
+        request: myFormDataPlugin
+      })
+    }
+  }
+```
+
 ## Plugin execution order
 
 Zodios plugins that are not attached to an endpoint are executed first.


### PR DESCRIPTION
Added an example in the overriding plugins section that clarifies that some in-built plugins are registered per-endpoint and must be overriden for every endpoint instead of globally (which I personally kept trying to do for two hours before realizing the dumb mistake I was making).

This clarification may not be that important for people that primarly use @zodios/core, however, I come from the openapi-zod-client world, and my zodios client file is auto-generated.