### PR TITLE
fix(docs): fix typo in `keepalive` parameter of pluginFetch()

### DIFF
--- a/website/docs/client/client.md
+++ b/website/docs/client/client.md
@@ -145,7 +145,7 @@ use(alias: string, plugin: ZodiosPlugin): PluginId;
 import { pluginFetch } from "@zodios/plugins";
 
 apiClient.use(pluginFetch({
-  keepAlive: true,
+  keepalive: true,
 }));
 ```
 

--- a/website/docs/client/plugins.md
+++ b/website/docs/client/plugins.md
@@ -21,7 +21,7 @@ import { pluginFetch } from "@zodios/plugins";
 
 apiClient.use(pluginFetch({
   // all fetch options are supported
-  keepAlive: true,
+  keepalive: true,
 }));
 ```
   


### PR DESCRIPTION
Fixed a typo in the `keepalive` parameter of `pluginFetch()` in the following section of the documentation.

- https://www.zodios.org/docs/client#zodiosuse
- https://www.zodios.org/docs/client/plugins#fetch-plugin

Reference to keepalive parameter definition
https://github.com/ecyrbe/zodios-plugins/blob/160036394b783d37897ad2eebf30223c8cc22058/src/fetch/fetch.types.ts#L14