### PR TITLE
fix: throw ZodiosError when server is unconnectable and response is undefined

### DIFF
--- a/src/plugins/zod-validation.plugin.ts
+++ b/src/plugins/zod-validation.plugin.ts
@@ -93,6 +93,11 @@ export function zodValidationPlugin({
               `No endpoint found for ${config.method} ${config.url}`
             );
           }
+          if (!response) {
+              throw new ZodiosError(
+                `Zodios: Invalid response from endpoint '${endpoint.method} ${endpoint.path}': undefined`
+              )
+          }
           if (
             response.headers?.["content-type"]?.includes("application/json") ||
             response.headers?.["content-type"]?.includes(


### PR DESCRIPTION
I finally add an undefined check to throw an ZodiosError instead of ignore it silently.

When axios throw an AxiosError of `AxiosError: connect ECONNREFUSED 127.0.0.1:8000`, here would throw `TypeError: Cannot read properties of undefined (reading 'headers')` error, and node server will exit without calling error handler as express.js middleware. So I add these code to avoid `try-catch` block each time when calling zodios api client for common exception like this.