### PR TITLE
fix: Do not throw validation error for 204 empty responses

### DIFF
--- a/src/plugins/zod-validation.plugin.test.ts
+++ b/src/plugins/zod-validation.plugin.test.ts
@@ -269,6 +269,14 @@ received:
   "second": 111
 }`);
     });
+
+    it("should handle 204 No Content with empty string body", async () => {
+      const response204 = createEmptyResponse204();
+
+      await expect(
+        plugin.response!(api, createSampleConfig("/delete"), response204),
+      ).resolves.not.toThrow();
+    });
   });
 
   const notExistingConfig: ReadonlyDeep<AnyZodiosRequestOptions> = {
@@ -320,6 +328,18 @@ received:
       config: {},
       statusText: "OK",
     } as unknown as AxiosResponse);
+
+  const createEmptyResponse204 = (
+    overrides?: Partial<AxiosResponse>,
+  ): AxiosResponse =>
+    ({
+      data: "",
+      status: 204,
+      headers: {},
+      config: {},
+      statusText: "No Content",
+      ...overrides,
+    }) as unknown as AxiosResponse;
 
   const api = apiBuilder({
     path: "/parse",

--- a/src/plugins/zod-validation.plugin.ts
+++ b/src/plugins/zod-validation.plugin.ts
@@ -93,15 +93,21 @@ export function zodValidationPlugin({
               `No endpoint found for ${config.method} ${config.url}`
             );
           }
+
+          let parseData = response.data;
+
+          // Handle 204 No Content responses with empty body
+          if (response.status === 204 && !Boolean(response.data)) {
+            parseData = undefined;
+          }
+
           if (
             response.headers?.["content-type"]?.includes("application/json") ||
             response.headers?.["content-type"]?.includes(
               "application/vnd.api+json"
             )
           ) {
-            const parsed = await endpoint.response.safeParseAsync(
-              response.data
-            );
+            const parsed = await endpoint.response.safeParseAsync(parseData);
             if (!parsed.success) {
               throw new ZodiosError(
                 `Zodios: Invalid response from endpoint '${endpoint.method} ${


### PR DESCRIPTION
This PR resolves issue #307 and https://github.com/astahmer/openapi-zod-client/issues/274 .

Before this change,  Zodios would erroneously throw a validation error for 204 responses where the server did not return any content. Specifically, it would result in 

```json
  {
    "code": "invalid_type",
    "expected": "void",
    "received": "string",
    "path": [],
    "message": "Expected void, received string"
  }
``` 