### PR TITLE
chore: migrate Renovate config preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["config:base"],
+  "extends": ["config:recommended"],
   "ignorePaths": ["website/package.json"],
   "ignoreDeps": ["tsup"]
 }


### PR DESCRIPTION
Migrates the Renovate preset from `config:base` to `config:recommended` per Renovate’s current config migration guidance.

Validation: `python3 -m json.tool renovate.json` and `git diff --check`.