### PR TITLE
chore: add bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "email": "ecyrbe@gmail.com"
   },
   "homepage": "https://github.com/ecyrbe/zodios",
+  "bugs": {
+    "url": "https://github.com/ecyrbe/zodios/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ecyrbe/zodios.git"


### PR DESCRIPTION
## Summary\n- add npm bugs metadata for @zodios/core\n- point bugs.url to the public GitHub issue tracker\n\nMicrobounty reference: charles-openclaw/charles-microbounties#708\n\n## Validation\n- node -e "const p=require('./package.json'); if (p.bugs?.url !== 'https://github.com/ecyrbe/zodios/issues') { console.error(p.bugs); process.exit(1) }"\n- npm pack --dry-run --ignore-scripts\n- git diff --check